### PR TITLE
Add combat marker to primary canvas group so it can be sorted

### DIFF
--- a/monks-combat-marker.js
+++ b/monks-combat-marker.js
@@ -46,7 +46,9 @@ export let patchFunc = (prop, func, type = "WRAPPER") => {
     }
 }
 
-class MonksCombatMarkerSprite extends PIXI.Sprite {
+
+
+class CombatMarker extends PIXI.Sprite {
     constructor(texture) {
         super(texture);
     }
@@ -200,7 +202,7 @@ export class MonksCombatMarker {
                     if (token.combatMarker != undefined) {
                         token.combatMarker.destroy();
                     }
-                    const markericon = new MonksCombatMarkerSprite(tex);
+                    const markericon = new CombatMarker(tex);
                     if (highlightFile.endsWith('webm') && tex?.baseTexture?.resource?.source) {
                         tex.baseTexture.resource.source.autoplay = true;
                         tex.baseTexture.resource.source.loop = true;
@@ -222,6 +224,7 @@ export class MonksCombatMarker {
                     canvas.primary.addChild(token.combatMarker);
                     token.combatMarker.visible = visible && token.isVisible && !MonksCombatMarker.isDefeated(token);
                     token.combatMarker._visible = visible;
+                    token.combatMarker.elevation = token.document.elevation;
                 }
 
                 if (MonksCombatMarker.markerCache[highlightFile] && !MonksCombatMarker.markerCache[highlightFile]?.baseTexture?.destroyed)
@@ -239,6 +242,7 @@ export class MonksCombatMarker {
                 const size = Math.max(token.w, token.h) * scale;
                 token.combatMarker.width = token.combatMarker.height = size;
                 token.combatMarker.alpha = 0.8;
+                token.combatMarker.elevation = token.document.elevation;
             }
 
             if (visible)
@@ -434,6 +438,11 @@ Hooks.on("updateToken", function (document, data, options, userid) {
     if (setting('token-highlight-remove') && (data.x != undefined || data.y != undefined)) {
         token.preventMarker = true;
         MonksCombatMarker.removeTurnMarker(token);
+    }
+    if (token.combatMarker) {
+        if (data.elevation !== undefined) {
+            token.combatMarker.elevation = data.elevation;
+        }
     }
 });
 

--- a/monks-combat-marker.js
+++ b/monks-combat-marker.js
@@ -46,6 +46,16 @@ export let patchFunc = (prop, func, type = "WRAPPER") => {
     }
 }
 
+class MonksCombatMarkerSprite extends PIXI.Sprite {
+    constructor(texture) {
+        super(texture);
+    }
+
+    get sortLayer() {
+        return PrimaryCanvasGroup.SORT_LAYERS.TOKENS - 1;
+    }
+}
+
 export class MonksCombatMarker {
     static _setting = {};
     static markerCache = {};
@@ -190,7 +200,7 @@ export class MonksCombatMarker {
                     if (token.combatMarker != undefined) {
                         token.combatMarker.destroy();
                     }
-                    const markericon = new PIXI.Sprite(tex);
+                    const markericon = new MonksCombatMarkerSprite(tex);
                     if (highlightFile.endsWith('webm') && tex?.baseTexture?.resource?.source) {
                         tex.baseTexture.resource.source.autoplay = true;
                         tex.baseTexture.resource.source.loop = true;
@@ -209,7 +219,7 @@ export class MonksCombatMarker {
                     markericon.alpha = 0.8;
                     markericon.pulse = { value: null, dir: 1 };
                     token.combatMarker = markericon;
-                    canvas.regions.combatmarkers.addChild(token.combatMarker);
+                    canvas.primary.addChild(token.combatMarker);
                     token.combatMarker.visible = visible && token.isVisible && !MonksCombatMarker.isDefeated(token);
                     token.combatMarker._visible = visible;
                 }
@@ -561,8 +571,4 @@ Hooks.on("destroyToken", (token) => {
         token.combatMarker.destroy();
         delete token.combatMarker;
     }
-});
-
-Hooks.on("drawRegionLayer", function (layer) {
-    layer.combatmarkers = layer.addChildAt(new PIXI.Container(), layer.children.length - 1);
 });


### PR DESCRIPTION
Fixes #1 

I found that the combat marker was always displaying over swarm tokens: https://foundryvtt.com/packages/swarm.  This PR fixes that as well.